### PR TITLE
contracts/BlankArt: Remove unused contract dependencies

### DIFF
--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
-import "@openzeppelin/contracts/access/Ownable.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
-import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 
-contract BlankArt is ERC721, EIP712, ERC721Enumerable, ERC721URIStorage, Ownable {
+contract BlankArt is ERC721, EIP712, ERC721URIStorage {
     // An event whenever the foundation address is updated
     event FoundationAddressUpdated(address foundationAddress);
 
@@ -67,7 +65,7 @@ contract BlankArt is ERC721, EIP712, ERC721Enumerable, ERC721URIStorage, Ownable
         address from,
         address to,
         uint256 tokenId
-    ) internal override(ERC721, ERC721Enumerable) {
+    ) internal override(ERC721) {
         super._beforeTokenTransfer(from, to, tokenId);
     }
 
@@ -234,7 +232,7 @@ contract BlankArt is ERC721, EIP712, ERC721Enumerable, ERC721URIStorage, Ownable
         public
         view
         virtual
-        override(ERC721, ERC721Enumerable)
+        override(ERC721)
         returns (bool)
     {
         return ERC721.supportsInterface(interfaceId);


### PR DESCRIPTION
Remove unused contract dependencies to reduce contract size and improve security by reducing the surface area of the ABI. 

## Contract size
- Before
![Screen Shot 2021-10-15 at 11 19 08 AM](https://user-images.githubusercontent.com/1591297/137535460-9555e699-43ed-4959-ad5b-818a736d2021.png)

- After
![Screen Shot 2021-10-15 at 11 24 00 AM](https://user-images.githubusercontent.com/1591297/137535481-ae47d4e7-0b46-46a1-bd7e-6d10b4477458.png)
