### PR TITLE
Added public minting and setPrice functionality

### DIFF
--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -147,13 +147,9 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         mintPrice = price;
     }
     
-    // Set the ability to mint publically
-    function updatePublicMint(bool publicallyAvailable) external onlyFoundation {
-        // Verify that this would be a change
-        require(publicMint != publicallyAvailable, "Public minting is already set");
-
-        // Update the publicMint boolean
-        publicMint = publicallyAvailable;
+    // Toggle the value of publicMint
+    function togglePublicMint() external onlyFoundation {        
+        publicMint = !publicMint;
     }
 
     function _mintBlank(address owner) private returns (uint256) {

--- a/test/blankArt-test.js
+++ b/test/blankArt-test.js
@@ -247,9 +247,13 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);
+    
+    await contract.togglePublicMint();
+
+    expect(await contract.publicMint()).to.equal(false);
   });
 
   it("should not allow you to update the public mint period from the wrong sender", async () => {
@@ -259,36 +263,18 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await expect(contract.connect(addr2).updatePublicMint(true)).to.be.revertedWith("Only the foundation can make this call");
+    await expect(contract.connect(addr2).togglePublicMint()).to.be.revertedWith("Only the foundation can make this call");
 
     expect(await contract.publicMint()).to.equal(false);
   });
-
-  it("should not allow the foundation to update the public mint period if it is already set to the new value", async () => {
-    const { contract, redeemerContract, redeemer, minter } = await deploy()
-
-    expect(await contract.publicMint()).to.equal(false);
-
-    await expect(contract.updatePublicMint(false)).to.be.revertedWith("Public minting is already set");
-
-    expect(await contract.publicMint()).to.equal(false);
-
-    await contract.updatePublicMint(true);    
-
-    expect(await contract.publicMint()).to.equal(true);
-
-    await expect(contract.updatePublicMint(true)).to.be.revertedWith("Public minting is already set");
-
-    expect(await contract.publicMint()).to.equal(true);
-  });
-  
+ 
   it("Should allow anyone to mint one Blank NFT for free if public minting is enabled", async function() {
     const { contract, redeemerContract, redeemer, minter } = await deploy()
     const [_, __, addr2] = await ethers.getSigners()
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);
 
@@ -303,7 +289,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);
 
@@ -318,7 +304,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);
 
@@ -331,7 +317,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);
 
@@ -350,7 +336,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);    
 
@@ -374,7 +360,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);    
 
@@ -398,7 +384,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);    
 
@@ -421,7 +407,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
 
-    await contract.updatePublicMint(true);
+    await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);    
 


### PR DESCRIPTION
Added support for public minting post the whitelist period, including the ability to enable/disable public minting and optionally set a price for minting.

Will resolves #9 if approved/merged.
Note:
Previously the deployment cost 2,554,034 gas. Adding public minting increased the deployment cost to an estimated 2,753,402 gas, or approximately $55 additional to support public minting.

The cost to mint an NFT during the public minting period is actually less than during the whitelist period, due to the reduced load from not validating the voucher. 

Before:
![image](https://user-images.githubusercontent.com/40212583/138141140-11a5d8a4-e93d-49b9-a67d-58b41913833a.png)

After:
![image](https://user-images.githubusercontent.com/40212583/138141190-79a8e94f-bedd-4b81-9a97-5ceecc4a6834.png)
