### PR TITLE
Added tokenURI support, including updating the baseURI (evolution) and locking the URI per token.

### DIFF
--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -142,15 +142,6 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         emit FoundationAddressUpdated(newFoundationAddress);
     }
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
     // Locks a token's URI from being updated. Only callable by the token owner.
     function lockTokenURI(uint256 tokenId) external {
         // ensure that this token exists

--- a/test/blankArt-test.js
+++ b/test/blankArt-test.js
@@ -119,6 +119,43 @@ describe("BlankArt", function () {
 
   });
 
+  it("Should allow the Foundation to evolve the NFTs", async function() {
+    const { contract, redeemerContract, redeemer, minter } = await deploy()
+
+    const lazyMinter = new LazyMinter({ contract, signer: minter })
+    const voucher = await lazyMinter.createVoucher(redeemer.address)
+
+    await expect(redeemerContract.redeemVoucher(3, voucher))
+      .to.emit(contract, 'Transfer');
+
+    //Verify tokenURIs are correct (v1)
+    expect(await redeemerContract.tokenURI(1)).to.equal(arWeaveURI[0] + "1");
+
+    //Evolve the NFTs
+    await contract.connect(minter).addBaseURI(arWeaveURI[1]);
+
+    //Verify tokenURIs are correct (v2)
+    expect(await redeemerContract.tokenURI(1)).to.equal(arWeaveURI[1] + "1");
+
+  });
+
+  it("Should not allow an address other than the Foundation to evolve the NFTs", async function() {
+    const { contract, redeemerContract, redeemer, minter } = await deploy()
+
+    const lazyMinter = new LazyMinter({ contract, signer: minter })
+    const voucher = await lazyMinter.createVoucher(redeemer.address)
+
+    await expect(redeemerContract.redeemVoucher(3, voucher))
+      .to.emit(contract, 'Transfer');
+
+    //Verify tokenURIs are correct (v1)
+    expect(await redeemerContract.tokenURI(1)).to.equal(arWeaveURI[0] + "1");
+
+    //Evolve the NFTs
+    await expect(contract.connect(redeemer).addBaseURI(arWeaveURI[1])).to.be.revertedWith("Only the foundation can make this call");
+
+  });
+
   it("Should return the correct tokenURIs for both locked and unlocked NFTs", async function() {
     const { contract, redeemerContract, redeemer, minter } = await deploy()
 

--- a/test/deployBlankArt-test.js
+++ b/test/deployBlankArt-test.js
@@ -5,7 +5,7 @@ describe("Deploy BlankArt", function () {
   it("Should return the right name and symbol", async function () {
     const [owner, addr1] = await ethers.getSigners();
     const BlankArt = await ethers.getContractFactory("BlankArt");
-    const blankArt = await BlankArt.deploy(owner.address, 10000);
+    const blankArt = await BlankArt.deploy(owner.address, 10000, "ar://123456789/");
 
     await blankArt.deployed();
     expect(await blankArt.name()).to.equal("BlankArt");


### PR DESCRIPTION
Resolves #4 

- Added the ability for the foundation to push a new baseURI to facilitate the evolving versions
- Added the ability for the token owner to lock their URI on a prior version

**Important:** By default tokens will evolve, unless locked prior to the 'evolution' when the baseURI is updated by the foundation.

ToDo: Potentially update function names from `addBaseURI `and `lockTokenURI `to something like `evolve `and `remain`.
