### PR TITLE
Fix `Minted` event: it now emits the correct tokenURI in params

### DIFF
--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -45,10 +45,11 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
     // pending withdrawals by account address
     mapping(bytes32 => bool) private voucherClaimed;
 
-    constructor(address payable _foundationAddress, uint256 _maxTokenSupply, string memory baseURI)
-        ERC721("BlankArt", "BLANK")
-        EIP712(SIGNING_DOMAIN, SIGNATURE_VERSION)
-    {
+    constructor(
+        address payable _foundationAddress,
+        uint256 _maxTokenSupply,
+        string memory baseURI
+    ) ERC721("BlankArt", "BLANK") EIP712(SIGNING_DOMAIN, SIGNATURE_VERSION) {
         foundationSalePercentage = 50;
         memberMaxMintCount = 5;
         foundationAddress = _foundationAddress;
@@ -114,12 +115,10 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         string memory _base = "";
         require(_exists(tokenId), "ERC721URIStorage: URI query for nonexistent token");
 
-        if(tokenURILocked[tokenId] > 0)
-            _base = _baseURIs[tokenURILocked[tokenId]];
-        else
-            _base = _baseURIs[_baseURIs.length -1];
+        if (tokenURILocked[tokenId] > 0) _base = _baseURIs[tokenURILocked[tokenId]];
+        else _base = _baseURIs[_baseURIs.length - 1];
 
-        return string(abi.encodePacked(_base, Strings.toString(tokenId), '.json'));
+        return string(abi.encodePacked(_base, Strings.toString(tokenId), ".json"));
     }
 
     function _checkMemberMintCount(address account) internal view {
@@ -152,7 +151,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         // ensure that the token is owned by the caller
         require(ownerOf(tokenId) == msg.sender, "Invalid: Only the owner can lock their token");
         // lock this token's URI from being changed
-        tokenURILocked[tokenId] = _baseURIs.length-1;
+        tokenURILocked[tokenId] = _baseURIs.length - 1;
 
         emit TokenUriLocked(tokenId);
     }
@@ -163,13 +162,13 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         mintPrice = price;
     }
 
-        // Updates the memberMaxMintCount
+    // Updates the memberMaxMintCount
     function updateMaxMintCount(uint8 _maxMint) external onlyFoundation {
-        require(_maxMint > 0,  "Max mint cannot be zero");
+        require(_maxMint > 0, "Max mint cannot be zero");
         memberMaxMintCount = _maxMint;
     }
 
-        // Toggle the value of publicMint
+    // Toggle the value of publicMint
     function togglePublicMint() external onlyFoundation {
         publicMint = !publicMint;
     }
@@ -201,7 +200,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         // make sure caller is the redeemer
         require(msg.sender == voucher.redeemerAddress, "Voucher is for a different wallet address");
 
-       // make sure voucher has not expired.
+        // make sure voucher has not expired.
         require(block.timestamp <= voucher.expiration, "Voucher has expired");
 
         // make sure that the signer is the foundation address
@@ -212,18 +211,12 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
             "Amount is more than the minting limit"
         );
 
-        require(
-            tokenIndex + amount <= maxTokenSupply + 1,
-            "All tokens have already been minted"
-        );
+        require(tokenIndex + amount <= maxTokenSupply + 1, "All tokens have already been minted");
 
         // make sure that the redeemer is paying enough to cover the buyer's cost
         require(msg.value >= (voucher.minPrice * amount), "Insufficient funds to redeem");
 
-        require(
-            amount <= voucher.tokenCount,
-            "Amount is more than the voucher allows"
-        );
+        require(amount <= voucher.tokenCount, "Amount is more than the voucher allows");
 
         // make sure voucher has not already been claimed. If true, it HAS been claimed
         require(!voucherClaimed[_hash(voucher)], "Voucher has already been claimed");
@@ -242,21 +235,14 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
     }
 
     // Public mint function. Whitelisted members will utilize redeemVoucher()
-    function mint(uint256 amount)
-        public
-        payable
-        returns (uint256[] memory)
-    {
+    function mint(uint256 amount) public payable returns (uint256[] memory) {
         require(publicMint && active, "Public minting is not active.");
         require(
             balanceOf(msg.sender) + amount <= memberMaxMintCount,
             "Amount is more than the minting limit"
         );
 
-        require(
-            tokenIndex + amount <= maxTokenSupply + 1,
-            "All tokens have already been minted"
-        );
+        require(tokenIndex + amount <= maxTokenSupply + 1, "All tokens have already been minted");
 
         // make sure that the caller is paying enough to cover the mintPrice
         require(msg.value >= (mintPrice * amount), "Insufficient funds to mint");
@@ -295,7 +281,9 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
             _hashTypedDataV4(
                 keccak256(
                     abi.encode(
-                        keccak256("BlankNFTVoucher(address redeemerAddress,uint256 expiration,uint256 minPrice,uint16 tokenCount)"),
+                        keccak256(
+                            "BlankNFTVoucher(address redeemerAddress,uint256 expiration,uint256 minPrice,uint16 tokenCount)"
+                        ),
                         voucher.redeemerAddress,
                         voucher.expiration,
                         voucher.minPrice,

--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -10,10 +10,6 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
     // An event whenever the foundation address is updated
     event FoundationAddressUpdated(address foundationAddress);
 
-    event MemberAdded(address member);
-
-    event MemberRevoked(address member);
-
     event BaseTokenUriUpdated(string baseTokenURI);
 
     event TokenUriLocked(uint256 tokenId);
@@ -108,7 +104,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         emit BaseTokenUriUpdated(baseURI);
     }
 
-    // Overridden. Sets the TokenURI based on the locked version.
+    // Overridden. Gets the TokenURI based on the locked version.
     function tokenURI(uint256 tokenId)
         public
         view
@@ -166,20 +162,20 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         // Update the mintPrice
         mintPrice = price;
     }
-    
+
         // Updates the memberMaxMintCount
     function updateMaxMintCount(uint8 _maxMint) external onlyFoundation {
         require(_maxMint > 0,  "Max mint cannot be zero");
         memberMaxMintCount = _maxMint;
-    }   
+    }
 
         // Toggle the value of publicMint
-    function togglePublicMint() external onlyFoundation {        
+    function togglePublicMint() external onlyFoundation {
         publicMint = !publicMint;
     }
 
     // Pause minting
-    function toggleActivation() external onlyFoundation {        
+    function toggleActivation() external onlyFoundation {
         active = !active;
     }
 
@@ -188,7 +184,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         _checkMemberMintCount(owner);
         super._safeMint(owner, tokenId);
         tokenIndex++;
-        string memory tokenUri = super.tokenURI(tokenId);
+        string memory tokenUri = tokenURI(tokenId);
         emit Minted(tokenId, owner, tokenUri);
         return tokenId;
     }
@@ -204,7 +200,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         address signer = _verify(voucher);
         // make sure caller is the redeemer
         require(msg.sender == voucher.redeemerAddress, "Voucher is for a different wallet address");
-                
+
        // make sure voucher has not expired.
         require(block.timestamp <= voucher.expiration, "Voucher has expired");
 
@@ -256,7 +252,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
             balanceOf(msg.sender) + amount <= memberMaxMintCount,
             "Amount is more than the minting limit"
         );
-        
+
         require(
             tokenIndex + amount <= maxTokenSupply + 1,
             "All tokens have already been minted"

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -4,6 +4,7 @@ require('hardhat-abi-exporter');
 require('hardhat-gas-reporter');
 require('@typechain/hardhat');
 require('@nomiclabs/hardhat-ethers');
+require("hardhat-tracer");
 
 // This is a sample Hardhat task. To learn how to create your own go to
 // https://hardhat.org/guides/create-task.html

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "hardhat-abi-exporter": "^2.3.0",
     "hardhat-contract-sizer": "^2.1.1",
     "hardhat-gas-reporter": "^1.0.4",
+    "hardhat-tracer": "^1.0.0-alpha.6",
     "prettier": "^2.4.1",
     "prettier-plugin-solidity": "^1.0.0-beta.18",
     "typechain": "^5.2.0"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typechain": "hardhat typechain",
     "test": "hardhat test",
     "test:gas": "REPORT_GAS=true hardhat test",
+    "test:event-logs": "hardhat test --logs",
     "contract-sizes": "yarn run hardhat size-contracts",
     "deploy": "hardhat run scripts/deployBlankArt.js",
     "deploy:hardhat": "yarn deploy -- --network hardat --force",

--- a/scripts/deployBlankArt.js
+++ b/scripts/deployBlankArt.js
@@ -1,16 +1,16 @@
 async function main() {
-  const [deployer] = await ethers.getSigners();
+  const [deployer] = await ethers.getSigners()
 
-  console.log("Deploying contracts with the account:", deployer.address);
+  console.log('Deploying contracts with the account:', deployer.address)
 
-  console.log("Account balance:", (await deployer.getBalance()).toString());
+  console.log('Account balance:', (await deployer.getBalance()).toString())
 
-  const BlankArt = await ethers.getContractFactory("BlankArt")
-  const blankArt = await BlankArt.deploy(deployer.address, 10000);
+  const BlankArt = await ethers.getContractFactory('BlankArt')
+  const blankArt = await BlankArt.deploy(deployer.address, 10000)
 
   // Start deployment, returning a promise that resolves to a contract object
-  await blankArt.deployed();
-  console.log("Contract deployed to address:", blankArt.address);
+  await blankArt.deployed()
+  console.log('Contract deployed to address:', blankArt.address)
 }
 
 main()

--- a/scripts/metadataGeneration.js
+++ b/scripts/metadataGeneration.js
@@ -7,28 +7,35 @@
 
 const fs = require('fs')
 
-const PHOTO_BASE_URI = "https://arweave.net/yd87agVBoAGgneJ95QFyj1H_Xkk_CefZwLhYTNH1NlI"
+const PHOTO_BASE_URI = 'https://arweave.net/yd87agVBoAGgneJ95QFyj1H_Xkk_CefZwLhYTNH1NlI'
 
-const OUTPUT_FOLDER = "/tmp/metadata_upload/";
+const OUTPUT_FOLDER = '/tmp/metadata_upload/'
 
 const MAX_TOKEN_ID = 10000
 
 async function main() {
   for (var i = 1; i < MAX_TOKEN_ID + 1; i++) {
     let metadataJson = {
-        "name":  "Blank NFT",
-        "description": "In the beginning, there was Blank.",
-        "tokenId": i,
-        "image": PHOTO_BASE_URI, // in the future you may have to append "+ i.toString() + ".png""
-        "attributes": [{
-          "trait_type": "Generation",
-          "value": "The beginning"
-    }]};
-    fs.writeFileSync(OUTPUT_FOLDER + i.toString() + ".json", JSON.stringify(metadataJson), function(err) {
-      if (err) {
-        console.log(err);
-      }
-    });
+      name: 'Blank NFT',
+      description: 'In the beginning, there was Blank.',
+      tokenId: i,
+      image: PHOTO_BASE_URI, // in the future you may have to append "+ i.toString() + ".png""
+      attributes: [
+        {
+          trait_type: 'Generation',
+          value: 'The beginning',
+        },
+      ],
+    }
+    fs.writeFileSync(
+      OUTPUT_FOLDER + i.toString() + '.json',
+      JSON.stringify(metadataJson),
+      function (err) {
+        if (err) {
+          console.log(err)
+        }
+      },
+    )
   }
 }
 
@@ -36,7 +43,7 @@ async function main() {
 // and properly handle errors.
 main()
   .then(() => process.exit(0))
-  .catch(error => {
-    console.error(error);
-    process.exit(1);
-  });
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/test/blankArt-test.js
+++ b/test/blankArt-test.js
@@ -42,6 +42,8 @@ describe("BlankArt", function () {
 
     await expect(redeemerContract.redeemVoucher(1, voucher))
       .to.emit(contract, 'Transfer')  // transfer from null address to minter
+      .to.emit(contract, 'Minted')
+      .withArgs(1, redeemer.address, arWeaveURI[0] + '1.json');
   });
 
   it("Should redeem 5 free Blank NFTs from a signed voucher", async function() {
@@ -52,7 +54,9 @@ describe("BlankArt", function () {
 
     await expect(redeemerContract.redeemVoucher(5, voucher))
       .to.emit(contract, 'Transfer')  // transfer from null address to minter
-      //.withArgs('0x0000000000000000000000000000000000000000', redeemer.address, contract.tokenIndex - 1)
+      .to.emit(contract, 'Minted')
+      .withArgs(1, redeemer.address, arWeaveURI[0] + '1.json')
+      .withArgs(2, redeemer.address, arWeaveURI[0] + '2.json')
   });
 
   it("Should redeem 10 free Blank NFTs from a signed voucher with a limit of 10", async function() {
@@ -776,6 +780,6 @@ describe("BlankArt", function () {
 
     await expect(contract.connect(addr2).mint(1))
         .to.emit(contract, 'Minted')
-        .withArgs(1, addr2.address, arWeaveURI[0] + '1');
+        .withArgs(1, addr2.address, arWeaveURI[0] + '1.json');
   });
 });

--- a/test/blankArt-test.js
+++ b/test/blankArt-test.js
@@ -11,7 +11,7 @@ describe("BlankArt", function () {
   arWeaveURI.push("https://arweave.net/hash2/");
 
   const voucherExpiration = 86400; //Voucher expires in 24 hours.
-  const expiration = (Math.floor( Date.now() / 1000 )+voucherExpiration);  
+  const expiration = (Math.floor( Date.now() / 1000 )+voucherExpiration);
 
   async function deploy(maxTokenSupply) {
       const [minter, redeemer, _] = await ethers.getSigners()
@@ -34,12 +34,12 @@ describe("BlankArt", function () {
   }
 
   it("Should redeem one free Blank NFT from a signed voucher", async function() {
-    const { contract, redeemerContract, redeemer, minter } = await deploy()    
+    const { contract, redeemerContract, redeemer, minter } = await deploy()
 
     const lazyMinter = new LazyMinter({ contract, signer: minter })
-        
+
     const voucher = await lazyMinter.createVoucher(redeemer.address, expiration);
-    
+
     await expect(redeemerContract.redeemVoucher(1, voucher))
       .to.emit(contract, 'Transfer')  // transfer from null address to minter
   });
@@ -165,15 +165,15 @@ describe("BlankArt", function () {
   });
 
   it("Should error on an attempt to redeem a voucher while redemption is paused", async function() {
-    const { contract, redeemerContract, redeemer, minter } = await deploy()    
+    const { contract, redeemerContract, redeemer, minter } = await deploy()
 
     const lazyMinter = new LazyMinter({ contract, signer: minter })
-        
+
     const voucher = await lazyMinter.createVoucher(redeemer.address, expiration);
-    
+
     // Pause Redemption
     await contract.toggleActivation();
-    
+
     await expect(redeemerContract.redeemVoucher(1, voucher))
       .to.be.revertedWith("Voucher redemption is not currently active");
   });
@@ -292,7 +292,7 @@ describe("BlankArt", function () {
 
     // Expect to be on the v2 URI
     expect(await redeemerContract.tokenURI(3)).to.equal(arWeaveURI[1] + "3.json");
-    
+
   });
 
   it("should allow you to check membership if an address has minted", async () => {
@@ -351,11 +351,11 @@ describe("BlankArt", function () {
   });
 
   it("Should fail to redeem an NFT voucher that's expired", async function() {
-    const { contract, redeemerContract, redeemer, minter } = await deploy()    
+    const { contract, redeemerContract, redeemer, minter } = await deploy()
 
     const lazyMinter = new LazyMinter({ contract, signer: minter })
 
-    let expired = (Math.floor( Date.now() / 1000 )-1);         
+    let expired = (Math.floor( Date.now() / 1000 )-1);
     const voucher = await lazyMinter.createVoucher(redeemer.address, expired);
 
     await expect(redeemerContract.redeemVoucher(1, voucher))
@@ -461,11 +461,11 @@ describe("BlankArt", function () {
 
     expect(await contract.mintPrice()).to.equal(0);
   });
-  
+
   it("Should not allow you to mint up to 5 Blank NFTs if public minting is not enabled", async function() {
     const { redeemerContract } = await deploy()
 
-    await expect(redeemerContract.mint(5)).to.be.revertedWith("Public minting is not active.");    
+    await expect(redeemerContract.mint(5)).to.be.revertedWith("Public minting is not active.");
   });
 
   it("should allow the foundation to update the public mint period", async () => {
@@ -476,7 +476,7 @@ describe("BlankArt", function () {
     await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(true);
-    
+
     await contract.togglePublicMint();
 
     expect(await contract.publicMint()).to.equal(false);
@@ -493,7 +493,7 @@ describe("BlankArt", function () {
 
     expect(await contract.publicMint()).to.equal(false);
   });
- 
+
   it("Should allow anyone to mint one Blank NFT for free if public minting is enabled", async function() {
     const { contract } = await deploy()
     const [_, __, addr2] = await ethers.getSigners()
@@ -574,7 +574,7 @@ describe("BlankArt", function () {
       await expect(contract.connect(addr2).mint(4))
       .to.be.revertedWith("Amount is more than the minting limit");
   });
-  
+
   it("Should allow anyone to mint one Blank NFT if public minting is enabled, mint price is set and payment is conveyed", async function() {
     const { contract } = await deploy()
     const [_, __, addr2] = await ethers.getSigners()
@@ -584,7 +584,7 @@ describe("BlankArt", function () {
 
     await contract.togglePublicMint();
 
-    expect(await contract.publicMint()).to.equal(true);    
+    expect(await contract.publicMint()).to.equal(true);
 
     expect(await contract.mintPrice()).to.equal(0);
 
@@ -608,7 +608,7 @@ describe("BlankArt", function () {
 
     await contract.togglePublicMint();
 
-    expect(await contract.publicMint()).to.equal(true);    
+    expect(await contract.publicMint()).to.equal(true);
 
     expect(await contract.mintPrice()).to.equal(0);
 
@@ -632,7 +632,7 @@ describe("BlankArt", function () {
 
     await contract.togglePublicMint();
 
-    expect(await contract.publicMint()).to.equal(true);    
+    expect(await contract.publicMint()).to.equal(true);
 
     expect(await contract.mintPrice()).to.equal(0);
 
@@ -655,7 +655,7 @@ describe("BlankArt", function () {
 
     await contract.togglePublicMint();
 
-    expect(await contract.publicMint()).to.equal(true);    
+    expect(await contract.publicMint()).to.equal(true);
 
     expect(await contract.mintPrice()).to.equal(0);
 
@@ -674,13 +674,13 @@ describe("BlankArt", function () {
     const testMaxToken = 25;
     const { contract } = await deploy(testMaxToken)
     const [_, __, addr2, addr3, addr4, addr5, addr6, addr7] = await ethers.getSigners()
-    const price = ethers.constants.WeiPerEther // charge 1 Eth    
+    const price = ethers.constants.WeiPerEther // charge 1 Eth
 
     expect(await contract.publicMint()).to.equal(false);
 
     await contract.togglePublicMint();
 
-    expect(await contract.publicMint()).to.equal(true);    
+    expect(await contract.publicMint()).to.equal(true);
 
     expect(await contract.mintPrice()).to.equal(0);
 
@@ -706,7 +706,7 @@ describe("BlankArt", function () {
 
     await expect(contract.connect(addr6).mint(5, { value: payment }))
     .to.emit(contract, 'Transfer')  // transfer from null address to minter
-    
+
     // Attempt to mint an extra NFT
     await expect(contract.connect(addr7).mint(1, { value: payment }))
       .to.be.revertedWith('All tokens have already been minted')
@@ -720,7 +720,7 @@ describe("BlankArt", function () {
     await contract.toggleActivation();
 
     expect(await contract.active()).to.equal(false);
-    
+
     await contract.toggleActivation();
 
     expect(await contract.active()).to.equal(true);
@@ -746,7 +746,7 @@ describe("BlankArt", function () {
     await contract.updateMaxMintCount(10);
 
     expect(await contract.memberMaxMintCount()).to.equal(10);
-    
+
     await contract.updateMaxMintCount(7);
 
     expect(await contract.memberMaxMintCount()).to.equal(7);
@@ -764,4 +764,18 @@ describe("BlankArt", function () {
     expect(await contract.memberMaxMintCount()).to.equal(5);
   });
 
+  it("Should emit a valid tokenURI in the Mint event params", async function() {
+    const { contract } = await deploy()
+    const [_, __, addr2] = await ethers.getSigners()
+
+    expect(await contract.publicMint()).to.equal(false);
+
+    await contract.togglePublicMint();
+
+    expect(await contract.publicMint()).to.equal(true);
+
+    await expect(contract.connect(addr2).mint(1))
+        .to.emit(contract, 'Minted')
+        .withArgs(1, addr2.address, arWeaveURI[0] + '1');
+  });
 });


### PR DESCRIPTION
- Use the BlankArt `tokenURI` function in `_mintBlank` instead of the inherited `tokenURI` function.
- Include a test to ensure `Minted` events emit correct param values.
- Add [hardhat-tracer](https://github.com/zemse/hardhat-tracer) for debugging events.
- Removed the unused `MemberAdded` and `MemberRevoked` events.