### PR TITLE
Emit Initialized event with token parameters during deploy()

### DIFF
--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -7,6 +7,16 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "@openzeppelin/contracts/utils/cryptography/draft-EIP712.sol";
 
 contract BlankArt is ERC721, EIP712, ERC721URIStorage {
+    event Initialized(
+        address controller,
+        string baseURI,
+        uint256 mintPrice,
+        uint256 maxTokenSupply,
+        uint256 foundationSalePercentage,
+        bool active,
+        bool publicMint
+    );
+
     // An event whenever the foundation address is updated
     event FoundationAddressUpdated(address foundationAddress);
 
@@ -62,6 +72,15 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage {
         // Default the initial index to 1. The lockTokenURI map will default to 0 for all unmapped tokens.
         _baseURIs.push(baseURI);
         active = true;
+        emit Initialized(
+            foundationAddress,
+            baseURI,
+            mintPrice,
+            maxTokenSupply,
+            foundationSalePercentage,
+            active,
+            publicMint
+        );
     }
 
     /// @notice Represents a voucher to claim any un-minted NFT (up to memberMaxMintCount), which has not yet been recorded into the blockchain. A signed voucher can be redeemed for real NFTs using the redeemVoucher function.

--- a/test/blankArt-test.js
+++ b/test/blankArt-test.js
@@ -782,4 +782,29 @@ describe("BlankArt", function () {
         .to.emit(contract, 'Minted')
         .withArgs(1, addr2.address, arWeaveURI[0] + '1.json');
   });
+
+  it("Should emit Initialized event during deploy", async function() {
+    const [minter, redeemer, _] = await ethers.getSigners()
+    let factory = await ethers.getContractFactory("BlankArt")
+    let interface = factory.interface
+
+    const maxTokenSupply = 10000
+    const baseTokenUri = arWeaveURI[0]
+    const controller = minter.address
+
+    const unsignedTx = factory.getDeployTransaction(controller, maxTokenSupply, baseTokenUri);
+    const tx = await factory.signer.sendTransaction(unsignedTx);
+    const receipt = await tx.wait(1)
+    const parsedLog = interface.parseLog(receipt.logs[0])
+
+    expect(parsedLog.name).to.equal('Initialized')
+    expect(parsedLog.signature).to.equal('Initialized(address,string,uint256,uint256,uint256,bool,bool)')
+    expect(parsedLog.args).to.have.property('controller', '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266')
+    expect(parsedLog.args).to.have.property('baseURI', baseTokenUri)
+    expect(parsedLog.args.mintPrice).to.equal(0)
+    expect(parsedLog.args.maxTokenSupply).to.equal(maxTokenSupply)
+    expect(parsedLog.args.foundationSalePercentage).to.equal(50)
+    expect(parsedLog.args).to.have.property('active', true)
+    expect(parsedLog.args).to.have.property('publicMint', false)
+  })
 });


### PR DESCRIPTION
I updated the contract to emit an `Initialized` event upon deploy and have included a unit test to confirm. The `Initialized` event params describe the initial configuration of the token. This data structure can be picked up by the subgraph to setup an initial state for base token configs. 