### PR TITLE
Initial commit adding EIP2981 support.

### DIFF
--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -118,17 +118,11 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
         super._burn(tokenId);
     }
 
-    // modifier for only allowing the foundation to make a call
-    modifier onlyFoundation() {
-        require(msg.sender == foundationAddress, "Only the foundation can make this call");
-        _;
-    }
-
     function isMember(address account) external view returns (bool) {
         return (balanceOf(account) > 0);
     }
 
-    function addBaseURI(string calldata baseURI) external onlyFoundation {
+    function addBaseURI(string calldata baseURI) external onlyOwner {
         _baseURIs.push(baseURI);
         emit BaseTokenUriUpdated(baseURI);
     }
@@ -166,7 +160,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
     }
 
     // Allows the current foundation address to update to something different
-    function updateFoundationAddress(address payable newFoundationAddress) external onlyFoundation {
+    function updateFoundationAddress(address payable newFoundationAddress) external onlyOwner {
         foundationAddress = newFoundationAddress;
 
         emit FoundationAddressUpdated(newFoundationAddress);
@@ -185,24 +179,24 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
     }
 
     // Updates the mintPrice
-    function updateMintPrice(uint256 price) external onlyFoundation {
+    function updateMintPrice(uint256 price) external onlyOwner {
         // Update the mintPrice
         mintPrice = price;
     }
 
     // Updates the memberMaxMintCount
-    function updateMaxMintCount(uint8 _maxMint) external onlyFoundation {
+    function updateMaxMintCount(uint8 _maxMint) external onlyOwner {
         require(_maxMint > 0, "Max mint cannot be zero");
         memberMaxMintCount = _maxMint;
     }
 
     // Toggle the value of publicMint
-    function togglePublicMint() external onlyFoundation {
+    function togglePublicMint() external onlyOwner {
         publicMint = !publicMint;
     }
 
     // Pause minting
-    function toggleActivation() external onlyFoundation {
+    function toggleActivation() external onlyOwner {
         active = !active;
     }
 
@@ -287,7 +281,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
     }
 
     /// @notice Transfers all pending withdrawal balance to the caller. Reverts if the caller is not an authorized minter.
-    function withdraw() public onlyFoundation {
+    function withdraw() public onlyOwner {
         // IMPORTANT: casting msg.sender to a payable address is only safe if ALL members of the minter role are payable addresses.
         address payable receiver = payable(msg.sender);
 
@@ -298,7 +292,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
     }
 
     /// @notice Retuns the amount of Ether available to the caller to withdraw.
-    function availableToWithdraw() public view onlyFoundation returns (uint256) {
+    function availableToWithdraw() public view onlyOwner returns (uint256) {
         return pendingWithdrawals[msg.sender];
     }
 
@@ -363,7 +357,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
     /// @param bps uint256 amount of fee (1% == 100)
     function setDefaultRoyalty(address recipient, uint16 bps)
         public
-        onlyFoundation
+        onlyOwner
     {
         blankRoyalty = RoyaltyInfo(recipient, bps);
         emit BlankRoyaltySet(recipient, bps);

--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -65,7 +65,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
     // EIP2981
     struct RoyaltyInfo {
         address recipient;
-        uint16 bps;
+        uint24 bps;
     }
     RoyaltyInfo public blankRoyalty;
 

--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -14,7 +14,6 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
         string baseURI,
         uint256 mintPrice,
         uint256 maxTokenSupply,
-        uint256 foundationSalePercentage,
         bool active,
         bool publicMint
     );
@@ -38,8 +37,6 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
     string private constant SIGNATURE_VERSION = "1";
     // Array of _baseURIs
     string[] private _baseURIs;
-    // the percentage of sale that the foundation gets on secondary sales
-    uint256 public foundationSalePercentage;
     // gets incremented to placehold for tokens not minted yet
     uint256 public maxTokenSupply;
     // cost to mint during the public sale
@@ -72,7 +69,6 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
         string memory baseURI,
         uint16 _royaltyBPS
     ) ERC721("BlankArt", "BLANK") EIP712(SIGNING_DOMAIN, SIGNATURE_VERSION) {
-        foundationSalePercentage = 50;
         memberMaxMintCount = 5;
         foundationAddress = _foundationAddress;
         maxTokenSupply = _maxTokenSupply;
@@ -89,7 +85,6 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
             baseURI,
             mintPrice,
             maxTokenSupply,
-            foundationSalePercentage,
             active,
             publicMint
         );

--- a/contracts/BlankArt.sol
+++ b/contracts/BlankArt.sol
@@ -24,7 +24,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
 
     event BaseTokenUriUpdated(string baseTokenURI);
 
-    event TokenUriLocked(uint256 tokenId);
+    event PermanentURI(string _value, uint256 indexed _id); // https://docs.opensea.io/docs/metadata-standards
 
     event Minted(uint256 tokenId, address member, string tokenURI);
 
@@ -186,7 +186,7 @@ contract BlankArt is ERC721, EIP712, ERC721URIStorage, Ownable, IERC2981 {
         // lock this token's URI from being changed
         tokenURILocked[tokenId] = _baseURIs.length - 1;
 
-        emit TokenUriLocked(tokenId);
+        emit PermanentURI(tokenURI(tokenId), tokenId);
     }
 
     // Updates the mintPrice

--- a/contracts/IERC2981.sol
+++ b/contracts/IERC2981.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+///
+/// @dev Interface for the NFT Royalty Standard
+///
+interface IERC2981 is IERC165 {
+    /// ERC165 bytes to add to interface array - set in parent contract
+    /// implementing this standard
+    ///
+    /// bytes4(keccak256("royaltyInfo(uint256,uint256)")) == 0x2a55205a
+    /// bytes4 private constant _INTERFACE_ID_ERC2981 = 0x2a55205a;
+    /// _registerInterface(_INTERFACE_ID_ERC2981);
+
+    /// @notice Called with the sale price to determine how much royalty
+    //          is owed and to whom.
+    /// @param _tokenId - the NFT asset queried for royalty information
+    /// @param _salePrice - the sale price of the NFT asset specified by _tokenId
+    /// @return receiver - address of who should be sent the royalty payment
+    /// @return royaltyAmount - the royalty payment amount for _salePrice
+    function royaltyInfo(
+        uint256 _tokenId,
+        uint256 _salePrice
+    ) external view returns (
+        address receiver,
+        uint256 royaltyAmount
+    );
+}

--- a/test/blankArt-test.js
+++ b/test/blankArt-test.js
@@ -903,7 +903,6 @@ describe("BlankArt", function () {
     expect(parsedLog.args).to.have.property('baseURI', baseTokenUri)
     expect(parsedLog.args.mintPrice).to.equal(0)
     expect(parsedLog.args.maxTokenSupply).to.equal(maxTokenSupply)
-    expect(parsedLog.args.foundationSalePercentage).to.equal(50)
     expect(parsedLog.args).to.have.property('active', true)
     expect(parsedLog.args).to.have.property('publicMint', false)
   })

--- a/test/blankArt-test.js
+++ b/test/blankArt-test.js
@@ -289,7 +289,9 @@ describe("BlankArt", function () {
     expect(await redeemerContract.tokenURI(3)).to.equal(arWeaveURI[0] + "3.json");
 
     //Lock one of the tokenURIs
-    await redeemerContract.lockTokenURI(2);
+    expect(await redeemerContract.lockTokenURI(2))
+      .to.emit(contract, 'PermanentURI')
+      .withArgs(arWeaveURI[0] + '2.json', 2)
 
     //Evolve the NFTs
     await contract.addBaseURI(arWeaveURI[1]);

--- a/test/deployBlankArt-test.js
+++ b/test/deployBlankArt-test.js
@@ -5,7 +5,7 @@ describe("Deploy BlankArt", function () {
   it("Should return the right name and symbol", async function () {
     const [owner, addr1] = await ethers.getSigners();
     const BlankArt = await ethers.getContractFactory("BlankArt");
-    const blankArt = await BlankArt.deploy(owner.address, 10000, "ar://123456789/");
+    const blankArt = await BlankArt.deploy(owner.address, 10000, "ar://123456789/", 1000);
 
     await blankArt.deployed();
     expect(await blankArt.name()).to.equal("BlankArt");

--- a/test/deployBlankArt-test.js
+++ b/test/deployBlankArt-test.js
@@ -3,9 +3,9 @@ const { ethers } = require("hardhat");
 
 describe("Deploy BlankArt", function () {
   it("Should return the right name and symbol", async function () {
-    const [owner, addr1] = await ethers.getSigners();
+    const [owner, addr1, voucherSigner] = await ethers.getSigners();
     const BlankArt = await ethers.getContractFactory("BlankArt");
-    const blankArt = await BlankArt.deploy(owner.address, 10000, "ar://123456789/", 1000);
+    const blankArt = await BlankArt.deploy(owner.address, voucherSigner.address, 10000, "ar://123456789/", 1000);
 
     await blankArt.deployed();
     expect(await blankArt.name()).to.equal("BlankArt");


### PR DESCRIPTION
- Added EIP2981 Support
- Implemented `PermanentURI `event when tokenID locks, per https://docs.opensea.io/docs/metadata-standards
- Removed `foundationSalePercentage `as it is now encompassed in EIP2981
- Removed `onlyFoundation `modifier to replace with native `onlyOwner`, now that we've included `Ownable` from OpenZepellin as part of the EIP2981 changes
- Added support for one or more`voucherSigner `addresses, separate from the `foundationAddress`, due to challenges signing the voucher from the multi-sig.